### PR TITLE
fix: Display header and subheader on web page

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -46,9 +46,12 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    padding: 2rem;
+    text-align: center;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
 }
 
 header h1 {


### PR DESCRIPTION
This PR fixes the missing header issue by removing the CSS rule that was hiding it.

The header "Course Materials Assistant" and its subheader were already present in the HTML but hidden with `display: none;` in the CSS. This change makes them visible with proper styling.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)